### PR TITLE
Allow Property Owners to Edit Their Listings

### DIFF
--- a/routes/listingRoutes.js
+++ b/routes/listingRoutes.js
@@ -10,12 +10,15 @@ router.use(getUserFromSession);
 
 // GET routes
 router.get("/new", checkAuth, listingController.getNewListing);
-router.get("/:id", listingController.getListingById);
+router.get("/:id/edit", checkAuth, listingController.getEditListing);
 router.get("/:id", listingController.getListingById);
 
 // POST routes
 router.post("/:id/review", checkAuth, reviewController.createReview);
 router.post("/", upload.single("image"), listingController.createListing);
+
+// PUT routes
+router.put("/:id", checkAuth, listingController.updateListing);
 
 // DELETE routes
 router.delete("/:id", listingController.deleteListing);

--- a/views/editListing.ejs
+++ b/views/editListing.ejs
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Edit Listing | Housify</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900">
+
+  <!-- Header Include -->
+  <%- include('includes/header.ejs') %>
+
+  <!-- Edit Listing Form -->
+  <section class="max-w-4xl mx-auto px-6 py-10">
+    <div class="bg-white rounded-xl shadow-lg p-8">
+      <h1 class="text-3xl font-bold mb-6">Edit Listing</h1>
+      
+      <form action="/listing/<%= listing.ID %>" method="POST" class="space-y-6">
+        <input type="hidden" name="_method" value="PUT">
+        
+        <!-- Property Name -->
+        <div>
+          <label for="name" class="block text-sm font-medium text-gray-700 mb-2">Property Name</label>
+          <input 
+            type="text" 
+            id="name" 
+            name="name" 
+            value="<%= listing.NAME %>"
+            required 
+            class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+        </div>
+
+        <!-- Description -->
+        <div>
+          <label for="description" class="block text-sm font-medium text-gray-700 mb-2">Description</label>
+          <textarea 
+            id="description" 
+            name="description" 
+            rows="4" 
+            required 
+            class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          ><%= listing.DESCRIPTION %></textarea>
+        </div>
+
+        <!-- Address Fields -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label for="street" class="block text-sm font-medium text-gray-700 mb-2">Street</label>
+            <input 
+              type="text" 
+              id="street" 
+              name="street" 
+              value="<%= listing.STREET %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+          
+          <div>
+            <label for="city" class="block text-sm font-medium text-gray-700 mb-2">City</label>
+            <input 
+              type="text" 
+              id="city" 
+              name="city" 
+              value="<%= listing.CITY %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+          
+          <div>
+            <label for="state" class="block text-sm font-medium text-gray-700 mb-2">State</label>
+            <input 
+              type="text" 
+              id="state" 
+              name="state" 
+              value="<%= listing.STATE %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+          
+          <div>
+            <label for="pincode" class="block text-sm font-medium text-gray-700 mb-2">Pincode</label>
+            <input 
+              type="number" 
+              id="pincode" 
+              name="pincode" 
+              value="<%= listing.PINCODE %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+        </div>
+
+        <!-- Property Details -->
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div>
+            <label for="pricePerMonth" class="block text-sm font-medium text-gray-700 mb-2">Price per Month (₹)</label>
+            <input 
+              type="number" 
+              id="pricePerMonth" 
+              name="pricePerMonth" 
+              value="<%= listing.PRICEPERMONTH %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+          
+          <div>
+            <label for="discount" class="block text-sm font-medium text-gray-700 mb-2">Discount (%)</label>
+            <input 
+              type="number" 
+              id="discount" 
+              name="discount" 
+              value="<%= listing.DISCOUNT %>"
+              min="0" 
+              max="100" 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+          
+          <div>
+            <label for="size" class="block text-sm font-medium text-gray-700 mb-2">Size (sq ft)</label>
+            <input 
+              type="number" 
+              id="size" 
+              name="size" 
+              value="<%= listing.SIZE %>"
+              required 
+              class="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+          </div>
+        </div>
+
+        <!-- Availability -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">Availability</label>
+          <div class="flex items-center space-x-4">
+            <label class="flex items-center">
+              <input 
+                type="radio" 
+                name="availability" 
+                value="true" 
+                <%= listing.AVAILABILITY ? 'checked' : '' %>
+                class="mr-2"
+              >
+              <span>Available</span>
+            </label>
+            <label class="flex items-center">
+              <input 
+                type="radio" 
+                name="availability" 
+                value="false" 
+                <%= !listing.AVAILABILITY ? 'checked' : '' %>
+                class="mr-2"
+              >
+              <span>Not Available</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Current Image -->
+        <div>
+          <label class="block text-sm font-medium text-gray-700 mb-2">Current Image</label>
+          <img src="<%= listing.IMAGE_URL %>" alt="Property Image" class="w-64 h-48 object-cover rounded-lg border">
+          <p class="text-sm text-gray-500 mt-2">Note: Image cannot be changed in this edit form. Contact support if you need to update the image.</p>
+        </div>
+
+        <!-- Form Actions -->
+        <div class="flex justify-end space-x-4 pt-6">
+          <a 
+            href="/listing/<%= listing.ID %>" 
+            class="bg-gray-300 text-gray-700 px-6 py-2 rounded-lg hover:bg-gray-400 transition duration-200"
+          >
+            Cancel
+          </a>
+          <button 
+            type="submit" 
+            class="bg-blue-600 text-white px-6 py-2 rounded-lg hover:bg-blue-700 transition duration-200"
+          >
+            Update Listing
+          </button>
+        </div>
+      </form>
+    </div>
+  </section>
+
+</body>
+</html>

--- a/views/listings.ejs
+++ b/views/listings.ejs
@@ -13,7 +13,14 @@
 
   <!-- Listing Title -->
   <section class="text-center py-6">
-    <h1 class="text-4xl font-bold tracking-tight"><%= listing.NAME %></h1>
+    <div class="flex items-center justify-center gap-4">
+      <h1 class="text-4xl font-bold tracking-tight"><%= listing.NAME %></h1>
+      <% if (user && user.USER_ID && user.USER_ID === listing.USER_ID) { %>
+        <a href="/listing/<%= listing.ID %>/edit" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition duration-200">
+          Edit Listing
+        </a>
+      <% } %>
+    </div>
   </section>
 
   <!-- Full-Width Listing Image -->


### PR DESCRIPTION
Problem: After creating a listing, owners cannot update changing details like price, availability, or description.
Goal: Enable authenticated owners to edit their own listings via a secure, pre-populated form.
What to build-
UI
Show an Edit Listing button on the listing details page.
Button is visible only to the owner (user.USER_ID === listing.USER_ID).
An edit page with a form pre-filled with existing data.
Routes
GET /listing/:id/edit: Render edit form with existing listing data.
PUT /listing/:id: Update listing fields.
Authorization
Auth required for both routes.
Ownership check: only the listing owner can access/edit.
Fields to edit
Name, description, street, city, state, pincode
Price per month, discount, size
Availability (true/false)

Acceptance criteria-
Edit button appears only for the listing owner.
Edit form loads with current values.
Submitting updates persists changes to the database.
After update, user is redirected to /listing/:id and sees the new values.
Unauthorized users (not owner or not logged in) cannot access edit routes.

How to test
Log in as the listing owner and open /listing/:id.
Verify the Edit Listing button is visible; click it.
On /listing/:id/edit, change fields (e.g., price, availability) and submit.
Confirm you are redirected to /listing/:id and changes are displayed.
Log in as a different user; verify the edit button is hidden and direct access to /listing/:id/edit or PUT /listing/:id is denied.
